### PR TITLE
Fixed invalid free memory

### DIFF
--- a/src/output-plugins/spo_alert_json.c
+++ b/src/output-plugins/spo_alert_json.c
@@ -1013,8 +1013,10 @@ static void AlertJSONCleanup(int signal, void *arg, const char* msg)
         freeNumberStrAssocList(data->services);
         freeNumberStrAssocList(data->protocols);
         freeNumberStrAssocList(data->vlans);
-        while((template_element = output_template_first(&data->output_template)))
-        {
+
+        while(!TAILQ_EMPTY(&data->output_template)) {
+            template_element = output_template_first(&data->output_template);
+            TAILQ_REMOVE(&data->output_template, template_element, qentry);
             free(template_element);
         }
 


### PR DESCRIPTION
1417 ==1438==
1418 ==1438== More than 100 errors detected.  Subsequent errors
1419 ==1438== will still be recorded, but in less detail than before.
1420 ==1438== Invalid free() / delete / delete[] / realloc()
1421 ==1438==    at 0x4C27430: free (vg_replace_malloc.c:446)
1422 ==1438==    by 0x4202DC: AlertJSONCleanup (spo_alert_json.c:1018)
1423 ==1438==    by 0x403EF2: Barnyard2Cleanup (barnyard2.c:1122)
1424 ==1438==    by 0x40428C: SignalCheck (barnyard2.c:1405)
1425 ==1438==    by 0x405E1F: Barnyard2Main (barnyard2.c:395)
1426 ==1438==    by 0x6185D5C: (below main) (in /lib64/libc-2.12.so)
1427 ==1438==  Address 0x79cc8e0 is 0 bytes inside a block of size 24
free'd
1428 ==1438==    at 0x4C27430: free (vg_replace_malloc.c:446)
1429 ==1438==    by 0x4202DC: AlertJSONCleanup (spo_alert_json.c:1018)
1430 ==1438==    by 0x403EF2: Barnyard2Cleanup (barnyard2.c:1122)
1431 ==1438==    by 0x40428C: SignalCheck (barnyard2.c:1405)
1432 ==1438==    by 0x405E1F: Barnyard2Main (barnyard2.c:395)
1433 ==1438==    by 0x6185D5C: (below main) (in /lib64/libc-2.12.so)